### PR TITLE
Add typing for fib function

### DIFF
--- a/src/fib.ts
+++ b/src/fib.ts
@@ -1,5 +1,5 @@
 // util function that computes the fibonacci numbers
-export default function fibonacci(n) {
+export default function fibonacci(n: number): number {
   if (n < 0) {
     return -1;
   } else if (n == 0) {


### PR DESCRIPTION
This resolves #2 . I defined types for the variables in the function. I confirmed that the lint errors are gone with `npm run lint`.