### PR TITLE
Add typing for fibroute

### DIFF
--- a/src/fibRoute.ts
+++ b/src/fibRoute.ts
@@ -1,8 +1,13 @@
 // Endpoint for querying the fibonacci numbers
 
 import fibonacci from "./fib";
+import { Request, Response } from "express";
 
-export default (req, res) => {
+interface fibRouteParams {
+  num: string;
+}
+
+export default (req: Request<fibRouteParams>, res: Response) => {
   const { num } = req.params;
 
   const fibN = fibonacci(parseInt(num));


### PR DESCRIPTION
This resolves #1. I defined types for the function, which required using the Express Request and Response objects. I confirmed that the lint errors are gone with `npm run lint`